### PR TITLE
hands-on_native-service: Clarify commands needed for adb sync

### DIFF
--- a/hands-on_native-service/README.md
+++ b/hands-on_native-service/README.md
@@ -47,10 +47,16 @@ installed.
 To install it by hand the system partition needs to be writable.
 
 ```
+# Only needed once (and again if full 'm' build is performed and cuttlefish is restarted):
 adb root
-# Only needed once (`adb reboot` required)
 adb disable-verity
+adb reboot
+
+# Needed after every reboot of device:
+adb root
 adb remount system
+
+# To upload changed files:
 adb sync system
 ```
 


### PR DESCRIPTION
Make the README.md more clear what commands are needed before adb sync will work and when the steps need to be repeated.