### PR TITLE
remove binder service

### DIFF
--- a/hands-on_native-service/demo_service.h
+++ b/hands-on_native-service/demo_service.h
@@ -15,7 +15,7 @@ namespace demo {
 
 static constexpr char kDemoServiceName[] = "demoservice";
 
-class DemoService : public android::BinderService<DemoService>, public BnDemoService {
+class DemoService : public BnDemoService {
   public:
     static void RegisterService(const char* name);
 


### PR DESCRIPTION
Remove BinderService as base class for DemoService, since BinderService [is marked deprecated](https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/native/libs/binder/include/binder/BinderService.h).